### PR TITLE
Hotfix/old date for next aw

### DIFF
--- a/content/posts/event-aw-2023-04-14.md
+++ b/content/posts/event-aw-2023-04-14.md
@@ -1,5 +1,5 @@
 title: AW Pustervik 2023-04-14
-date: 2023-04-09
+date: 2023-04-14
 modified:
 author: Anders Nord
 category: Event


### PR DESCRIPTION
Wrong date for next AW in the header is presumably what is causing it to end up in "past events" rather than "upcoming events". This should fix the issue.