### PR TITLE
RENOVA articles: Changed to 'post-image-left' class for pictures

### DIFF
--- a/content/posts/renova-intervju-sasha-2023-10-05.md
+++ b/content/posts/renova-intervju-sasha-2023-10-05.md
@@ -6,9 +6,9 @@ tags: cirkularitet, jordbruk, återvinning, renova, processanalys, intervju
 data:
 status: published
 
-<div class="post-image-center">
+<div class="post-image-left">
     <img alt="Sasha Faminoff vid Renovas experimentella kompostanläggning."
-    src="data/sasha_faminoff.jpg" width=100%/>
+    src="data/sasha_faminoff.jpg"/>
     <em>Sasha Faminoff vid Renovas experimentella kompostanläggning.</em>
 </div>
 

--- a/content/posts/renova-sammanfattning-2023-10-05.md
+++ b/content/posts/renova-sammanfattning-2023-10-05.md
@@ -6,9 +6,8 @@ tags: cirkularitet, jordbruk, återvinning, renova, processanalys
 data:
 status: published
 
-<div class="post-image-center">
-    <img alt="Jerker och Sasha på båt." src="data/jerker_och_sasha.jpg"
-    width=100%/>
+<div class="post-image-left">
+    <img alt="Jerker och Sasha på båt." src="data/jerker_och_sasha.jpg"/>
     <em>Jerker Nilsson och Sasha Faminoff diskuterar Renovas industrialiserade komposteringsprocess
     i skärgården.</em>
 </div>


### PR DESCRIPTION
Tried to use "post-image-center", which did not exist. Compensated  by setting width=100%. Should of course use the css template, which states images to the left. This has now been fixed.